### PR TITLE
Made CrateDriver compatible with driver.Driver

### DIFF
--- a/crate.go
+++ b/crate.go
@@ -19,7 +19,7 @@ type CrateDriver struct {
 
 // Init a new "Connection" to a Crate Data Storage instance.
 // Note that the connection is not tested until the first query.
-func (c CrateDriver) Open(crate_url string) (driver.Conn, error) {
+func (c *CrateDriver) Open(crate_url string) (driver.Conn, error) {
 	u, err := url.Parse(crate_url)
 
 	if err != nil {

--- a/crate.go
+++ b/crate.go
@@ -19,7 +19,7 @@ type CrateDriver struct {
 
 // Init a new "Connection" to a Crate Data Storage instance.
 // Note that the connection is not tested until the first query.
-func (c *CrateDriver) Open(crate_url string) (driver.Conn, error) {
+func (c CrateDriver) Open(crate_url string) (driver.Conn, error) {
 	u, err := url.Parse(crate_url)
 
 	if err != nil {
@@ -192,13 +192,13 @@ func (r *Rows) Close() error {
 }
 
 // Yet not supported
-func (c *CrateDriver) Begin() (driver.Tx, error) {
+func (c CrateDriver) Begin() (driver.Tx, error) {
 	err := errors.New("Transactions are not supported by this driver.")
 	return nil, err
 }
 
 // Nothing to close, crate is stateless
-func (c *CrateDriver) Close() error {
+func (c CrateDriver) Close() error {
 	return nil
 }
 
@@ -209,10 +209,10 @@ type CrateStmt struct {
 }
 
 // Driver method that initiates the prepared stmt interface
-func (c *CrateDriver) Prepare(query string) (driver.Stmt, error) {
+func (c CrateDriver) Prepare(query string) (driver.Stmt, error) {
 	stmt := &CrateStmt{
 		stmt:   query,
-		driver: c,
+		driver: &c,
 	}
 
 	return stmt, nil


### PR DESCRIPTION
Made changes to the receiver signatures so that `CrateDriver` is now compatible with `driver.Driver`. This allows for type assertions of the form:

```
crate_driver, ok := db.Driver().(crate.CrateDriver)
```

to succeed, where `db` has type `sql.DB`.