### PR TITLE
Add CircleCI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 go-crate
 ========
 
+[![CircleCI](https://circleci.com/gh/herenow/go-crate.svg?style=svg)](https://circleci.com/gh/herenow/go-crate)
+
 Golang Sql Driver for Crate Data Storage. (https://crate.io/)
 
 [http://godoc.org/github.com/herenow/go-crate](http://godoc.org/github.com/herenow/go-crate)

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,9 @@
+dependencies:
+  pre:
+    - docker pull crate && docker run -p=4200:4200 -d=true crate && sleep 10
+machine:
+  environment:
+    CRATE_URL: http://localhost:4200/
+  services:
+    - docker
+

--- a/crate_test.go
+++ b/crate_test.go
@@ -1,13 +1,24 @@
 // NOTE: this tests were written posteriorly
 package crate
 
-import "testing"
-import "database/sql"
+import (
+	"database/sql"
+	"os"
+	"testing"
+)
 
-//import "fmt"
+var CRATE_URL string
+
+func init() {
+	CRATE_URL = os.Getenv("CRATE_URL")
+
+	if CRATE_URL == "" {
+		CRATE_URL = "http://localhost:4200"
+	}
+}
 
 func connect() (*sql.DB, error) {
-	return sql.Open("crate", "http://debian:4200/")
+	return sql.Open("crate", CRATE_URL)
 }
 
 func TestConnect(t *testing.T) {


### PR DESCRIPTION
This commit setups our tests to run on CircleCI.

Our tests had a hardcoded url to the database, I've decided to get the
url from an environment variable.

CircleCI does not provide a latest version of crate, so we need to
install it ourselves.