### PR TITLE
Fix blob driver.GetTable table existence check query

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -69,7 +69,7 @@ func (d *Driver) NewTable(name string, shards ...int) (*Table, error) {
 // or error when this table does not exist
 func (d *Driver) GetTable(name string) (*Table, error) {
 	row := d.db.QueryRow(
-		"select table_name from information_schema.tables where table_name = ? and schema_name = 'blob'",
+		"select table_name from information_schema.tables where table_name = ? and table_schema = 'blob'",
 		name,
 	)
 	if err := row.Scan(&name); err != nil {


### PR DESCRIPTION
Crate renamed the schema_name column to table_schema to be SQL
compliant, as of:

https://github.com/crate/crate/pull/4218

PS:

I'm not even sure we should try to query for a table existence check,
since:

a) This might not be a expected behaviour when initializing a new "table
driver" through driver.GetTable. We could provide another API for that.
b) Crate's information_schema is not "stable api", it will change from
version to versio.