### PR TITLE
Fix endpoint json response col_types unmarshal

### DIFF
--- a/crate.go
+++ b/crate.go
@@ -42,7 +42,7 @@ type endpointResponse struct {
 	} `json:"error"`
 	Cols        []string        `json:"cols"`
 	Duration    float64         `json:"duration"`
-	ColumnTypes []int           `json:"col_types"`
+	ColumnTypes []interface{}   `json:"col_types"`
 	Rowcount    int64           `json:"rowcount"`
 	Rows        [][]interface{} `json:"rows"`
 }


### PR DESCRIPTION
Fixes #13

Bug:

The `col_types` field, is not an array of integers, it may be a two
dimensional array if the column is a set or an array.

It may return something like:

`[ 4, [ 100, 4 ] ]`

Which means, the first column is a string, but the second is an array of
strings.

Fix:

Since we don't currently use the returned column types, I'm just going
to extract it to an arbitrary array of interfaces, and if anyone plans
on using endpointResponse.ColumnTypes they can parse the array values
type themselves.