### PR TITLE
Handle TimeStamp columns by converting int64 to time.Time and vice versa

### DIFF
--- a/crate.go
+++ b/crate.go
@@ -187,7 +187,7 @@ func encodeMap(buf *bytes.Buffer, obj reflect.Value) error {
 		}
 		buf.WriteString(fmt.Sprintf("\"%s\":", k))
 		fm := "%v"
-		v := obj.MapIndex(k).Elem()
+		v := obj.MapIndex(k)
 		vk := v.Kind()
 		if vk == reflect.Interface {
 			v = v.Elem()
@@ -198,6 +198,14 @@ func encodeMap(buf *bytes.Buffer, obj reflect.Value) error {
 			//Prevents rounding errors seen with floats like 0.01*41 which is 0.41000000000000003 ...
 			//See https://floating-point-gui.de/
 			buf.WriteString(fmt.Sprintf("%0.6f", v.Float()))
+			continue
+		case reflect.Int64, reflect.Int32, reflect.Int, reflect.Int8:
+			//Prevents rounding errors seen with floats like 0.01*41 which is 0.41000000000000003 ...
+			//See https://floating-point-gui.de/
+			buf.WriteString(fmt.Sprintf("%d", v.Int()))
+			continue
+		case reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8, reflect.Uint:
+			buf.WriteString(fmt.Sprintf("%d", v.Uint()))
 			continue
 		case reflect.Map:
 			t := reflect.TypeOf(v)

--- a/crate.go
+++ b/crate.go
@@ -18,25 +18,25 @@ import (
 
 // Crate conn structure
 type CrateDriver struct {
-	Url string // Crate http endpoint url
+	Url        string // Crate http endpoint url
 	username   string
 	password   string
 	httpClient *http.Client
 }
 
-//GeoPoint represents Crate GeoPoint column
+// GeoPoint represents Crate GeoPoint column
 type GeoPoint struct {
 	Lat float64
 	Lon float64
 }
 
-//CrateArray represents an Array column type
+// CrateArray represents an Array column type
 type CrateArray []interface{}
 
-//crateMap used to store any map and force our own MarshalJSON method to be called
+// crateMap used to store any map and force our own MarshalJSON method to be called
 type crateMap map[string]interface{}
 
-//Scan : Implements Scanner interface to populate a GeoPoint when the result is an array of 2 floats
+// Scan : Implements Scanner interface to populate a GeoPoint when the result is an array of 2 floats
 func (gp *GeoPoint) Scan(src interface{}) error {
 	if b, ok := src.([]interface{}); ok && len(b) == 2 {
 		var err error
@@ -50,7 +50,7 @@ func (gp *GeoPoint) Scan(src interface{}) error {
 	return fmt.Errorf("failed to convert %v to GeoPoint", src)
 }
 
-//Scan : Implements Scanner interface to populate a CrateArray from the incoming data
+// Scan : Implements Scanner interface to populate a CrateArray from the incoming data
 func (arr *CrateArray) Scan(src interface{}) error {
 	if srcArr, ok := src.([]interface{}); ok {
 		*arr = make([]interface{}, len(srcArr))
@@ -104,8 +104,8 @@ type endpointQuery struct {
 	Args []driver.Value `json:"args,omitempty"`
 }
 
-//encodeArray will encode the array represented by obj and store the result in buf
-//It returns an error if obj contains a map with keys other than strings
+// encodeArray will encode the array represented by obj and store the result in buf
+// It returns an error if obj contains a map with keys other than strings
 func encodeArray(buf *bytes.Buffer, obj reflect.Value) error {
 	m := obj.Len()
 	if m == 0 {
@@ -166,12 +166,12 @@ func encodeArray(buf *bytes.Buffer, obj reflect.Value) error {
 	return nil
 }
 
-//encodeMap will encode the map stored in obj in json and store it as a string in the buffer buf
-//This is used because one cannot rely on the json encoder because it will format any float with decimal part of 0 as an int
-//If the first value to be stored in a new object's key is an int then all further values will be stored as int
-//and one will loose the decimal part of each value... Our encoder will ensure that a float with a 0 decimal part
-//is encoded as X.0 and not X
-//Note it will not encode maps with keys other than strings
+// encodeMap will encode the map stored in obj in json and store it as a string in the buffer buf
+// This is used because one cannot rely on the json encoder because it will format any float with decimal part of 0 as an int
+// If the first value to be stored in a new object's key is an int then all further values will be stored as int
+// and one will loose the decimal part of each value... Our encoder will ensure that a float with a 0 decimal part
+// is encoded as X.0 and not X
+// Note it will not encode maps with keys other than strings
 func encodeMap(buf *bytes.Buffer, obj reflect.Value) error {
 	if obj.Len() == 0 {
 		buf.WriteString("{}")
@@ -234,7 +234,7 @@ func encodeMap(buf *bytes.Buffer, obj reflect.Value) error {
 	return nil
 }
 
-//MarshalJSON custom JSON marshal function to properly marshall maps containing floats with decimal part equals to 0
+// MarshalJSON custom JSON marshal function to properly marshall maps containing floats with decimal part equals to 0
 func (v crateMap) MarshalJSON() ([]byte, error) {
 	res := bytes.Buffer{}
 	if err := encodeMap(&res, reflect.ValueOf(v)); err != nil {
@@ -244,7 +244,7 @@ func (v crateMap) MarshalJSON() ([]byte, error) {
 	return res.Bytes(), nil
 }
 
-//MarshalJSON custom JSON marshal function to properly handle arrays of floats with decimal part equals to 0
+// MarshalJSON custom JSON marshal function to properly handle arrays of floats with decimal part equals to 0
 func (v CrateArray) MarshalJSON() ([]byte, error) {
 	res := bytes.Buffer{}
 	if err := encodeArray(&res, reflect.ValueOf(v)); err != nil {
@@ -254,7 +254,7 @@ func (v CrateArray) MarshalJSON() ([]byte, error) {
 	return res.Bytes(), nil
 }
 
-//CheckNamedValue Convert map, CrateArray, time & GeoPoint arguments to DB format.
+// CheckNamedValue Convert map, CrateArray, time & GeoPoint arguments to DB format.
 func (c *CrateDriver) CheckNamedValue(v *driver.NamedValue) error {
 	if obj, ok := v.Value.(map[string]interface{}); ok {
 		v.Value = crateMap(obj)
@@ -322,7 +322,7 @@ func (c *CrateDriver) query(stmt string, args []driver.Value) (*endpointResponse
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode >= 200 && resp.StatusCode <= 299 || resp.StatusCode >= 400 && resp.StatusCode <= 499 ||  resp.StatusCode >= 500 && resp.StatusCode <= 599 {
+	if resp.StatusCode >= 200 && resp.StatusCode <= 299 || resp.StatusCode >= 400 && resp.StatusCode <= 499 || resp.StatusCode >= 500 && resp.StatusCode <= 599 {
 		// Parse response
 		res := &endpointResponse{}
 		d := json.NewDecoder(resp.Body)
@@ -338,7 +338,7 @@ func (c *CrateDriver) query(stmt string, args []driver.Value) (*endpointResponse
 
 		// Check for db errors
 		if res.Error.Code != 0 {
-			err = &CrateErr{
+			err = CrateErr{
 				Code:    res.Error.Code,
 				Message: res.Error.Message,
 			}

--- a/crate.go
+++ b/crate.go
@@ -102,12 +102,21 @@ func encodeArray(buf *bytes.Buffer, obj reflect.Value) error {
 	}
 	buf.WriteByte('[')
 	var k reflect.Kind
+	ue := false
 	for i:=0; i<m; i++ {
 		v := obj.Index(i)
 		if i>0 {
 			buf.WriteByte(',')
+			if ue {
+				v = v.Elem()
+			}
 		} else {
 			k = v.Kind()
+			if k == reflect.Interface {
+				ue = true
+				v = v.Elem()
+				k = v.Type().Kind()
+			}
 		}
 		switch k {
 		case reflect.Float32, reflect.Float64:
@@ -163,7 +172,12 @@ func encodeMap(buf *bytes.Buffer, obj reflect.Value) error{
 		buf.WriteString(fmt.Sprintf("\"%s\":", k))
 		fm := "%v"
 		v := obj.MapIndex(k).Elem()
-		switch v.Kind() {
+		vk := v.Kind()
+		if vk == reflect.Interface {
+			v = v.Elem()
+			vk = v.Type().Kind()
+		}
+		switch vk {
 		case reflect.Float64, reflect.Float32:
 			f := v.Float()
 			i := float64(int64(f))

--- a/crate.go
+++ b/crate.go
@@ -130,6 +130,10 @@ func encodeArray(buf *bytes.Buffer, obj reflect.Value) error {
 				buf.WriteString(fmt.Sprintf("%0.1f", fv))
 				continue
 			}
+			//Prevents rounding errors seen with floats like 0.01*41 which is 0.41000000000000003 ...
+			//See https://floating-point-gui.de/
+			buf.WriteString(fmt.Sprintf("%0.6f", fv))
+			continue
 		case reflect.Map:
 			t := reflect.TypeOf(v)
 			if v.Type().Key().Kind() != reflect.String {

--- a/crate.go
+++ b/crate.go
@@ -158,7 +158,7 @@ func encodeMap(buf *bytes.Buffer, obj map[string]interface{}) error{
 					fv := v.Float()
 					i := float64(int32(fv))
 					if i == fv {
-						buf.WriteString(fmt.Sprintf("%0.1f", v))
+						buf.WriteString(fmt.Sprintf("%0.1f", v.Float()))
 						continue
 					}
 				}

--- a/crate.go
+++ b/crate.go
@@ -190,8 +190,13 @@ func encodeMap(buf *bytes.Buffer, obj reflect.Value) error{
 			f := v.Float()
 			i := float64(int64(f))
 			if i == f {
-				fm = "%0.1f"
+				buf.WriteString(fmt.Sprintf("%0.1f", f))
+				continue
 			}
+			//Prevents rounding errors seen with floats like 0.01*41 which is 0.41000000000000003 ...
+			//See https://floating-point-gui.de/
+			buf.WriteString(fmt.Sprintf("%0.6f", f))
+			continue
 		case reflect.Map:
 			t := reflect.TypeOf(v)
 			if v.Type().Key().Kind() != reflect.String {

--- a/crate.go
+++ b/crate.go
@@ -13,7 +13,6 @@ import (
 	"reflect"
 	"strings"
 	"time"
-	//"log"
 )
 
 // Crate conn structure
@@ -148,7 +147,7 @@ func encodeArray(buf *bytes.Buffer, obj reflect.Value) error {
 			}
 			continue
 		case reflect.String:
-			buf.WriteString(fmt.Sprintf("%s", strings.Replace(v.String(), "\"", "\\\"", -1)))
+			buf.WriteString(fmt.Sprintf("\"%s\"", strings.Replace(v.String(), "\"", "\\\"", -1)))
 			continue
 		}
 		buf.WriteString(fmt.Sprintf("%v", v))

--- a/errors.go
+++ b/errors.go
@@ -8,6 +8,6 @@ type CrateErr struct {
 }
 
 // Return error message, this is part of the error interface.
-func (e *CrateErr) Error() string {
+func (e CrateErr) Error() string {
 	return e.Message
 }


### PR DESCRIPTION
Since one cannot yet replace the driver.DefaultParameterConverter to properly handle type conversions (see https://github.com/golang/go/issues/18415)
I've made a quick patch to automatically handle TimeStamp (int64) columns conversion to time.Time by using the column type provided by Crate within the query’s results and to convert back to int64 any time.