### PR TITLE
add a method for closing the driver

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -94,6 +94,7 @@ func (d *Driver) GetTable(name string) (*Table, error) {
 	}, nil
 }
 
+// Close the database connection
 func (d *Driver) Close() {
 	if d.db != nil {
 		return d.db.Close()

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -94,6 +94,13 @@ func (d *Driver) GetTable(name string) (*Table, error) {
 	}, nil
 }
 
+func (d *Driver) Close() {
+	if d.db != nil {
+		return d.db.Close()
+	}
+	return nil
+}
+
 type Record struct {
 	Digest       string
 	LastModified time.Time


### PR DESCRIPTION
the driver keeps a reference to `sql.DB`, which spawns a go routine when its `Open` function is called. The `sql.DB` instance needs to be closed at some point to cleanup resources.