### PR TITLE
ColumnTypes() improvement.

### DIFF
--- a/crate.go
+++ b/crate.go
@@ -120,9 +120,10 @@ func (c *CrateDriver) Query(stmt string, args []driver.Value) (driver.Rows, erro
 
 	// Rows reader
 	rows := &Rows{
-		columns:  res.Cols,
-		values:   res.Rows,
-		rowcount: res.Rowcount,
+		columns:  		res.Cols,
+		columnTypes: 	res.ColumnTypes,
+		values:   		res.Rows,
+		rowcount: 		res.Rowcount,
 	}
 
 	return rows, nil
@@ -159,10 +160,11 @@ func (r *Result) RowsAffected() (int64, error) {
 
 // Rows reader
 type Rows struct {
-	columns  []string
-	values   [][]interface{}
-	rowcount int64
-	pos      int64 // index position on the values array
+	columns  	[]string
+	columnTypes []interface{}
+	values   	[][]interface{}
+	rowcount 	int64
+	pos      	int64 // index position on the values array
 }
 
 // Row columns
@@ -189,6 +191,34 @@ func (r *Rows) Next(dest []driver.Value) error {
 func (r *Rows) Close() error {
 	r.pos = r.rowcount // Set to end of list
 	return nil
+}
+
+var typeMap = map[int]string{
+	2: "byte",
+	3: "boolean",
+	4: "string",
+	5: "ip",
+	6: "double",
+	7: "float",
+	8: "short",
+	9: "integer",
+	10: "long",
+	11: "timestamp",
+	12: "object",
+	13: "geo_point",
+	14: "geo_shape",
+}
+
+func (r *Rows) ColumnTypeDatabaseTypeName(index int) string {
+	switch r.columnTypes[index].(type) {
+	case []interface{}:
+		x := r.columnTypes[index].([]interface{})
+		val, _ := x[1].(json.Number).Int64()
+		return fmt.Sprintf("array(%s)", typeMap[int(val)])
+	default:
+		val, _ := r.columnTypes[index].(json.Number).Int64()
+		return typeMap[int(val)]
+	}
 }
 
 // Yet not supported


### PR DESCRIPTION
it was impossible to extract column types with Rows.ColumnTypes() function.
but Crate's JSON response already contains column type information(col_types).
this commit contains implement `col_types`.
Look for following example codes.

Example Code:

package main

import (
    "fmt"
    "database/sql"
    _ "go-crate"
)

func main() {
    db, _ := sql.Open("crate", "http://127.0.0.1:4200")
    rows, _ := db.Query("select col1, col2 from tbl")
    types, _ := rows.ColumnTypes()
    for i, l := 0, len(types); i < l; i++ {
        t := types[i]
        fmt.Println(t.Name(), ":", t.DatabaseTypeName())
    }
}