### PR TITLE
Fixed blob close function to return an error

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -95,7 +95,7 @@ func (d *Driver) GetTable(name string) (*Table, error) {
 }
 
 // Close the database connection
-func (d *Driver) Close() {
+func (d *Driver) Close() error {
 	if d.db != nil {
 		return d.db.Close()
 	}


### PR DESCRIPTION
The function declaration did not have error as the return type even though the code was attempting to return a value, this change fixes that.