### PR TITLE
Allow for database user authentication

### DIFF
--- a/doc_test.go
+++ b/doc_test.go
@@ -15,6 +15,14 @@ func ExampleCrateDrive_Open() {
 	}
 }
 
+func ExampleCrateDrive_OpenUsernamePassword() {
+	_, err := sql.Open("crate", "http://username:password@localhost:4200")
+
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
 func ExampleCrateDriver_Query() {
 	db, err := sql.Open("crate", "http://localhost:4200")
 


### PR DESCRIPTION
Crate now supports user authentication, on the http api, it is done via
basic auth.

This commit aims to allow the driver to receive a username:password on
the connection uri and pass.

Usage examples:

```go
db, _ := sql.Open("crate", "http://username:password@localhost:4200/")
```

Read more about crate's authentication at:

https://crate.io/docs/crate/reference/en/latest/admin/auth/methods.html