### PR TITLE
Fixed CircleCI build, test cases and compilation issues.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,35 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.12.5
+
+    working_directory: /go/src/github.com/herenow/go-crate
+
+    environment:
+      CRATE_URL: "http://localhost:4200/"
+      JAVA_HOME: "/usr/lib/jvm/java-11-openjdk"
+
+    steps:
+      - checkout
+      - run:
+          command: |
+            sudo apt-get install default-jdk
+            mkdir ~/crate
+            wget -c https://cdn.crate.io/downloads/releases/crate-3.3.3.tar.gz -P ~/crate
+            tar -xzvf ~/crate/crate-3.3.3.tar.gz -C ~/crate
+            mv -v ~/crate/crate-3.3.3/* ~/crate
+            rm -r ~/crate/crate-3.3.3
+      - run: go get -v -t -d ./...
+      - run:
+          command: |
+            set -e
+            ~/crate/bin/crate & disown -a
+            sleep 25
+            go test -v -race ./...
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+.idea/
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/blob/blob_test.go
+++ b/blob/blob_test.go
@@ -23,7 +23,7 @@ func init() {
 func TestTableCreation(t *testing.T) {
 	table, err := driver.GetTable("myblobs")
 	if err != nil {
-		table, err = driver.NewTable("myblobs", 1, 1)
+		table, err = driver.NewTable("myblobs", 3, 0)
 	}
 	if err != nil {
 		t.Error(err)
@@ -31,7 +31,7 @@ func TestTableCreation(t *testing.T) {
 	}
 	t.Log(table.Name)
 
-	table, err = driver.NewTable("testTable", 1, 1)
+	table, err = driver.NewTable("testtable", 3, 0)
 	if err != nil {
 		t.Error(err.Error())
 		t.FailNow()

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,0 @@
-dependencies:
-  pre:
-    - docker pull crate && docker run -p=4200:4200 -d=true crate && sleep 10
-machine:
-  environment:
-    CRATE_URL: http://localhost:4200/
-  services:
-    - docker
-

--- a/crate_test.go
+++ b/crate_test.go
@@ -85,7 +85,7 @@ func TestQueryRowBigInt(t *testing.T) {
 	err := row.Scan(&test)
 
 	if err != nil {
-		t.Fatalf("Error on QueryRow.Scan", err)
+		t.Fatalf("Error on QueryRow.Scan - %v", err)
 	}
 
 	if test != 655300500 {
@@ -100,7 +100,7 @@ func TestPreparedStmtExec(t *testing.T) {
 	stmt2, err2 := db.Prepare("drop table go_crate")
 
 	if err != nil || err2 != nil {
-		t.Fatalf("Error on db.Prepared()", err, err2)
+		t.Fatalf("Error on db.Prepared() - %v - %v", err, err2)
 	}
 
 	_, err = stmt.Exec()


### PR DESCRIPTION
- Updated CircleCI config to v2. The build should hopefully pass now :)
[https://circleci.com/gh/chughpiyush/go-crate/46](https://circleci.com/gh/chughpiyush/go-crate/46)

- Fixed compilation issue to support latest GoLang version. I tested it on v1.12.5. The current master gives this compilation issue:
```
/crate_test.go:88:11: Fatalf call has arguments but no formatting directives
./crate_test.go:103:11: Fatalf call has arguments but no formatting directives
FAIL    github.com/herenow/go-crate [build failed]
```

- Fixed test cases in blob_test.go
The current scenario where we were setting both shards and replicas as 1, the time taken to create the blob was 30 seconds+ 
In the end it was giving **500 Server Error**

@herenow 